### PR TITLE
broken header and Time Predictor Card layout updated wrt mobile responsive

### DIFF
--- a/about.html
+++ b/about.html
@@ -248,6 +248,9 @@
         margin-bottom: 110px;
         height: 120px;
     }
+    .nav-item{
+            margin-left: 20px;
+    }
     #title {
         font-size: 35px;
     }
@@ -260,26 +263,26 @@
         font-size: 1.2rem;
         text-align: center;
     }
-  nav {
-    margin: 2%;
-    padding: 2%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    border: 2px blue;
-    background: rgb(3, 65, 90);
-    border-radius: 8px;
-  }
-  #first{
-      margin-left: 43px;margin-bottom: 7px;
-}
-#second{
-      margin-left: 40px ;margin-bottom: 7px;
-}
-#third{
-    margin-bottom: 7px;
-}
+    nav {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            background: rgb(3, 65, 90);
+            background: rgb(3, 65, 90);
+            border-radius: 8px;
+            padding: 10px;
+            margin: 0px;
+    }
+    #first{
+        margin-left: 43px;margin-bottom: 7px;
+    }
+    #second{
+        margin-left: 40px ;margin-bottom: 7px;
+    }
+    #third{
+        margin-bottom: 7px;
+    }   
 .container2 {
     
     width: 70%;
@@ -323,10 +326,11 @@
           </a>
           <nav class="md:ml-auto md:mr-auto flex flex-wrap items-center text-base justify-center">
     
-            <a class="mr-5 hover:text-white" href="index.html">Main Page</a>
-            <a class="mr-5 hover:text-white" href="about.html">About Us</a>
-            <a class="hover:text-white" href="#">Third Link</a>
-            <a class="mr-5 ml-5 hover:text-white" href="#">Fourth Link</a>
+    
+            <a class="hover:text-white nav-item" href="index.html">Main Page</a>
+            <a class="hover:text-white nav-item" href="about.html">About Us</a>
+            <a class="hover:text-white nav-item" href="#">Third Link</a>
+            <a class="hover:text-white nav-item" href="#">Fourth Link</a>
     
           </nav>
     

--- a/index.html
+++ b/index.html
@@ -55,9 +55,13 @@
         border-radius: 10px;
         background-color: rgb(197, 255, 197);
         width: 70%;
-        height: 80vh;
+        height: 90vh;
         /* margin-top: 110px;
         margin-bottom: 0%; */
+    }
+    .container2, input{
+        margin-left: 10px;
+        margin-right: 10px;
     }
     a {
         color: #2ac8f8;
@@ -83,7 +87,7 @@
     }
     .head {
         text-shadow: 4px 4px 4px rgba(250, 155, 77, 0.527);
-        margin-top: 0px;
+        margin: 10px;
         text-align: center;
         font-size: 3rem;
         color: rgb(240, 144, 0);
@@ -119,16 +123,11 @@
     #submit {
         border: 1px solid white;
         background-color: rgb(240, 144, 0);
-        position: relative;
+        height: 50px;
         color: white;
-        font-size: 2rem;
-        border-radius: 38px;
-        display: block;
-        margin: auto;
-        margin-top: 0px;
-        /* margin-top: 50px; */
-        padding: 6px;
+        font-size: 1.8rem;
         box-shadow: 4px 4px 7px 1px #888888;
+        border-radius: 10px;
     }
     #submit-dark {
         border: 1px solid black;
@@ -240,6 +239,9 @@
         margin-bottom: 110px;
         height: 120px;
     }
+    .nav-item{
+            margin-left: 20px;
+    }
     #title {
         font-size: 35px;
     }
@@ -264,20 +266,32 @@
             text-align: center;
         }
         nav {
-            margin: 2%;
-            padding: 2%;
             display: flex;
-            flex-direction: column;
             align-items: center;
             justify-content: center;
-            border: 2px blue;
+            flex-direction: column;
+            background: rgb(3, 65, 90);
             background: rgb(3, 65, 90);
             border-radius: 8px;
+            padding: 10px;
+            margin: 0px;
         } 
 
         .head {
             margin-top: 10px;
             font-size: 1.7rem;
+        }
+        .container2{
+            border: 5px green;
+            border-radius: 10px;
+            background-color: rgb(197, 255, 197);
+            width: 80%;
+            height: 80vh;
+        }
+
+        .container2, input{
+            margin-left: 10px;
+            margin-right: 10px;
         }
     }
 
@@ -312,14 +326,10 @@
       <nav class="md:ml-auto md:mr-auto flex flex-wrap items-center text-base justify-center">
 
 
-        <a class=" hover:text-white" href="index.html">Main Page</a>
-        <a class="mr-5 ml-5 hover:text-white" href="about.html">About Us</a>
-
-        <a class="mr-5 hover:text-white" href="index.html">Main Page</a>
-        <a class="mr-5 hover:text-white" href="about.html">About Us</a>
-
-        <a class="hover:text-white" href="#">Third Link</a>
-        <a class="mr-5 ml-5 hover:text-white" href="#">Fourth Link</a>
+        <a class="hover:text-white nav-item" href="index.html">Main Page</a>
+        <a class="hover:text-white nav-item" href="about.html">About Us</a>
+        <a class="hover:text-white nav-item" href="#">Third Link</a>
+        <a class="hover:text-white nav-item" href="#">Fourth Link</a>
 
       </nav>
 
@@ -327,6 +337,7 @@
 
     </div>
   </header>
+  
 
   <div id = "input-container" class="w-full h-screen flex flex-col justify-center max-w-2xl mx-auto items-center">
     <div class="flex flex-col gap-y-12 mx-auto justfiy-around w-full">


### PR DESCRIPTION
Broken layout of header in mobile view and normal view 
Updated images:
![image](https://user-images.githubusercontent.com/60876387/136649235-8ede41ab-c16b-489b-81d7-de5cb902676c.png)
![image](https://user-images.githubusercontent.com/60876387/136649245-462bc6f6-4939-483e-aeee-85a3dced4831.png)

Updated the Download Time Predictor Card:
Previous:
![image](https://user-images.githubusercontent.com/60876387/136649284-357a2b51-a4ea-4edf-9142-c5dc82f3c174.png)

Updated:
![image](https://user-images.githubusercontent.com/60876387/136649268-10c12863-3d9c-4840-9c3a-6f3b4d3ae083.png)

